### PR TITLE
[jest-image-snapshot] Fix customDiffConfig type

### DIFF
--- a/types/jest-image-snapshot/index.d.ts
+++ b/types/jest-image-snapshot/index.d.ts
@@ -19,7 +19,7 @@ export interface MatchImageSnapshotOptions {
     /**
      * Custom config passed to 'pixelmatch' or 'ssim'
      */
-    customDiffConfig?: PixelmatchOptions | SSIMOptions;
+    customDiffConfig?: PixelmatchOptions | Partial<SSIMOptions>;
     /**
      * The method by which images are compared.
      * `pixelmatch` does a pixel by pixel comparison, whereas `ssim` does a structural similarity comparison.


### PR DESCRIPTION
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

`customDiffConfig` should accept partial `SSIMOptions` as that is used as an argument here: 

**jest-image-snapshot usage**
[jest-image-snapshot/src/diff-snapshot.js](https://github.com/americanexpress/jest-image-snapshot/blob/d60e2e672e11dd9668122bcf8c3ac8a36bed0a8e/src/diff-snapshot.js#L102)

**ssim function**
[ssim/src/index.ts](https://github.com/obartra/ssim/blob/master/src/index.ts#L95)